### PR TITLE
Fix the Type Error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import Image from "next/image";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -37,10 +38,11 @@ export default function RootLayout({
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img
+          <Image
             src={mlh}
             alt="Major League Hacking 2025 Hackathon Season"
-            className="w-full"
+            width={100}
+            height={100}
           />
         </a>
         {children}

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -88,16 +88,16 @@ export const Navbar = () => {
 
             <div className="flex justify-center items-center z-10 absolute left-1/2 transform -translate-x-1/2 space-x-1 sm:space-x-2 md:space-x-4 hidden lg:flex">
               <NavLink href="#home" closeMenu={closeMenu}>
-                <h1 className="text-2xl">HOME</h1>
+                <h1 className="lg:text-lg xl:text-2xl">HOME</h1>
               </NavLink>
               <NavLink href="#about" closeMenu={closeMenu}>
-                <h1 className="text-2xl">ABOUT US</h1>
+                <h1 className="lg:text-lg xl:text-2xl">ABOUT US</h1>
               </NavLink>
               <NavLink href="#sponsor" closeMenu={closeMenu}>
-                <h1 className="text-2xl">SPONSORS</h1>
+                <h1 className="lg:text-lg xl:text-2xl">SPONSORS</h1>
               </NavLink>
               <NavLink href="#faq" closeMenu={closeMenu}>
-                <h1 className="text-2xl">FAQs</h1>
+                <h1 className="lg:text-lg xl:text-2xl">FAQs</h1>
               </NavLink>
               <Link
                 href="/documents/RocketHacks High School Flyer.pdf"


### PR DESCRIPTION
# Type Error
`Type error: Type '{ children: Element; href: string; className: string; closeMenu: () => void; }' is not assignable to type 'IntrinsicAttributes & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof InternalLinkProps> & InternalLinkProps & { ...; } & RefAttributes<...>'.`

# Bug Fix
Removed `closeMenu()` from Code&Create Navigation Link